### PR TITLE
Fix/ajustes layout cadastro usuário

### DIFF
--- a/packages/omni_auth/labels/register_labels/lib/labels.dart
+++ b/packages/omni_auth/labels/register_labels/lib/labels.dart
@@ -13,41 +13,33 @@ class RegisterLabels {
   static const verifyPersonalDataCPFPlaceholder = 'Informe seu CPF';
   static const verifyPersonalDataCPFError = 'Digite CPF válido.';
   static const verifyPersonalDataBirthDateLabel = 'Data de nascimento *';
-  static const verifyPersonalDataBirthDatePlaceholder =
-      'Informe sua data de nascimento';
+  static const verifyPersonalDataBirthDatePlaceholder = 'Informe sua data de nascimento';
   static const programFormMainText = 'Programa ou convênio';
   static const programFormCodeLabel = 'Código do programa *';
   static const programFormCodePlaceholder = 'Informe o código do programa';
   static const programFormCodeError = 'Código PSP inválido';
   static const personalDataFormMainText = 'Dados pessoais';
   static const personalDataFormFullNameLabel = 'Nome completo *';
-  static const personalDataFormFullNamePlaceholder =
-      'Informe seu nome completo';
+  static const personalDataFormFullNamePlaceholder = 'Informe seu nome completo';
   static const personalDataFormMotherNameLabel = 'Nome da mãe';
-  static const personalDataFormMotherNamePlaceholder =
-      'Informe o nome da sua mãe';
+  static const personalDataFormMotherNamePlaceholder = 'Informe o nome da sua mãe';
   static const personalDataFormFatherNameLabel = 'Nome do pai';
-  static const personalDataFormFatherNamePlaceholder =
-      'Informe o nome do seu pai';
+  static const personalDataFormFatherNamePlaceholder = 'Informe o nome do seu pai';
   static const personalDataFormPhoneLabel = 'Telefone *';
   static const personalDataFormPhonePlaceholder = 'Informe seu telefone';
   static const personalDataFormEthnicityLabel = 'Etnia';
   static const personalDataFormEthnicityPlaceholder = 'Selecione sua Etnia';
-  static const personalDataFormGenreLabel = 'Gênero';
+  static const personalDataFormGenreLabel = 'Gênero *';
   static const personalDataFormGenrePlaceholder = 'Gênero *';
   static const personalDataFormBloodTypeLabel = 'Tipo Sanguíneo';
-  static const personalDataFormGenreBloodTypePlaceholder =
-      'Selecione seu tipo sangíneo';
+  static const personalDataFormGenreBloodTypePlaceholder = 'Selecione seu tipo sangíneo';
   static const responsableDataFormMainText = 'Dados do responsável';
   static const responsableDataFormNameLabel = 'Nome do responsável *';
-  static const responsableDataFormNamePlaceholder =
-      'Informe o nome do responsável';
+  static const responsableDataFormNamePlaceholder = 'Informe o nome do responsável';
   static const responsableDataFormCPFLabel = 'CPF do responsável *';
-  static const responsableDataFormCPFPlacehodler =
-      'Informe o CPF do responsável';
+  static const responsableDataFormCPFPlacehodler = 'Informe o CPF do responsável';
   static const responsableDataFormRelationshipLabel = 'Parentesco *';
-  static const responsableDataFormRelationshipPlaceholder =
-      'Informe o tipo do parentesco';
+  static const responsableDataFormRelationshipPlaceholder = 'Informe o tipo do parentesco';
   static const addressFormMainText = 'Endereço';
   static const addressFormCEPLabel = 'CEP *';
   static const addressFormCEPPlaceholder = 'Informe seu código postal';
@@ -65,14 +57,12 @@ class RegisterLabels {
   static const accessDataFormEmailLabel = 'E-mail *';
   static const accessDataFormEmailPlaceholder = 'Informe seu e-mail';
   static const accessDataFormUsernameLabel = 'Nome de usuário *';
-  static const accessDataFormUsernamePlaceholder =
-      'Informe seu nome de usuário';
+  static const accessDataFormUsernamePlaceholder = 'Informe seu nome de usuário';
   static const accessDataFormPasswordLabel = 'Senha *';
   static const accessDataFormPasswordPlaceholder = 'Informe sua senha';
   static const accessDataFormConfirmPasswordLabel = 'Confirmação de senha *';
   static const accessDataFormConfirmPasswordPlaceholder = 'Confirme sua senha';
-  static const accessDataFormConfirmPasswordInaqualityError =
-      'As senhas não conferem.';
+  static const accessDataFormConfirmPasswordInaqualityError = 'As senhas não conferem.';
   static const termsCheckboxAccept = 'Aceito os ';
   static const termsCheckboxCoditions = 'Termos e Condições';
   static const termsCheckboxProgram = ' do programa ou convênio ';

--- a/packages/omni_auth/lib/src/modules/register/pages/register_page.dart
+++ b/packages/omni_auth/lib/src/modules/register/pages/register_page.dart
@@ -66,7 +66,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     children: [
                       VerifyPersonalDataPage(pageController: pageController),
                       ProgramFormPage(pageController: pageController),
-                      PersonalDataFormPage(pageController: pageController),
+                      // PersonalDataFormPage(pageController: pageController),
                       AddressFormPage(pageController: pageController),
                       AccessDataFormPage(pageController: pageController),
                       const RegisterSuccessPage(),

--- a/packages/omni_auth/lib/src/modules/register/pages/verify_personal_data_page.dart
+++ b/packages/omni_auth/lib/src/modules/register/pages/verify_personal_data_page.dart
@@ -4,19 +4,10 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_triple/flutter_triple.dart';
+import 'package:omni_auth/src/modules/register/pages/widgets/responsable_data_form_widget.dart';
 import 'package:omni_auth/src/modules/register/stores/register_store.dart';
-import 'package:omni_general/omni_general.dart'
-    show
-        BeneficiaryResponsibleModel,
-        BottomButtonType,
-        BottomButtonWidget,
-        DateTimePickerService,
-        Formaters,
-        Helpers,
-        Masks,
-        NewBeneficiaryModel,
-        RequestErrorWidget,
-        TextFieldWidget;
+import 'package:omni_general/omni_general.dart';
+
 import 'package:omni_register_labels/labels.dart';
 
 class VerifyPersonalDataPage extends StatefulWidget {
@@ -36,21 +27,29 @@ class _VerifyPersonalDataPageState extends State<VerifyPersonalDataPage> {
   late final TextEditingController birthController;
   late final TextEditingController cpfController;
   late final TextEditingController registrationController;
+  late final TextEditingController nameController;
+  late final TextEditingController phoneController;
+  late final TextEditingController genreController;
+
+  final FocusNode nameFocus = FocusNode();
+  final FocusNode phoneFocus = FocusNode();
+
   final RegisterStore store = Modular.get();
   final _formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
     cpfController = TextEditingController(
-      text: store.state.individualPerson?.cpf != null
-          ? Formaters.formatCPF(store.state.individualPerson!.cpf!)
-          : '',
+      text: store.state.individualPerson?.cpf != null ? Formaters.formatCPF(store.state.individualPerson!.cpf!) : '',
     );
     birthController = TextEditingController(
       text: store.state.individualPerson?.birth ?? '',
     );
 
     registrationController = TextEditingController();
+    nameController = TextEditingController();
+    phoneController = TextEditingController();
+    genreController = TextEditingController();
     super.initState();
   }
 
@@ -175,7 +174,6 @@ class _VerifyPersonalDataPageState extends State<VerifyPersonalDataPage> {
 
   Widget get _buildFormWidget {
     final mask = Masks.generateMask('###.###.###-##');
-    final maskRegistration = Masks.generateMask('#############');
     return TripleBuilder<RegisterStore, DioError, NewBeneficiaryModel>(
       store: store,
       builder: (_, triple) {
@@ -192,8 +190,7 @@ class _VerifyPersonalDataPageState extends State<VerifyPersonalDataPage> {
                 keyboardType: TextInputType.number,
                 onChange: (String? input) {
                   if (input == null) return;
-                  store.state.individualPerson!.cpf =
-                      input.replaceAll(RegExp(r'[^0-9]'), '');
+                  store.state.individualPerson!.cpf = input.replaceAll(RegExp(r'[^0-9]'), '');
                   store.updateForm(store.state);
                 },
                 validator: (String? input) {
@@ -209,14 +206,67 @@ class _VerifyPersonalDataPageState extends State<VerifyPersonalDataPage> {
               const SizedBox(height: 15),
               TextFieldWidget(
                 label: RegisterLabels.verifyPersonalDataBirthDateLabel,
-                placeholder:
-                    RegisterLabels.verifyPersonalDataBirthDatePlaceholder,
+                placeholder: RegisterLabels.verifyPersonalDataBirthDatePlaceholder,
                 readOnly: true,
                 isEnabled: !triple.isLoading,
                 controller: birthController,
                 onTap: chooseBirthDate,
                 suffixIcon: const Icon(Icons.date_range),
               ),
+              const SizedBox(height: 15),
+              TextFieldWidget(
+                label: RegisterLabels.personalDataFormFullNameLabel,
+                controller: nameController,
+                placeholder: RegisterLabels.personalDataFormFullNamePlaceholder,
+                textCapitalization: TextCapitalization.words,
+                textInputAction: TextInputAction.next,
+                focusNode: nameFocus,
+                onSubmitted: (String input) {
+                  Helpers.changeFocus(context, nameFocus, phoneFocus);
+                },
+                onChange: (String? input) {
+                  store.state.individualPerson!.name = input ?? '';
+                  store.updateForm(store.state);
+                },
+              ),
+              const SizedBox(height: 15),
+              TextFieldWidget(
+                label: RegisterLabels.personalDataFormPhoneLabel,
+                placeholder: RegisterLabels.personalDataFormPhonePlaceholder,
+                mask: Masks.generateMask('(##) # ####-####'),
+                controller: phoneController,
+                keyboardType: TextInputType.number,
+                textInputAction: TextInputAction.next,
+                focusNode: phoneFocus,
+                onSubmitted: (String input) {
+                  FocusScope.of(context).requestFocus(FocusNode());
+                },
+                onChange: (String? input) {
+                  input = input!.replaceAll('(', '');
+                  input = input.replaceAll(')', '');
+                  input = input.replaceAll('-', '');
+                  input = input.replaceAll(' ', '');
+                  store.state.individualPerson!.phone = input;
+                  // store.updateForm(store.state);
+                },
+              ),
+              const SizedBox(height: 15),
+              SelectFieldWidget<GenreType>(
+                label: RegisterLabels.personalDataFormGenreLabel,
+                items: GenreType.values,
+                itemsLabels: GenreType.values.map((type) => type.label).toList(),
+                placeholder: RegisterLabels.personalDataFormGenrePlaceholder,
+                controller: genreController,
+                // focusNode: genreFocus,
+                onSelectItem: (GenreType type) {
+                  genreController.text = type.label;
+                  store.state.individualPerson!.genre = type;
+                  store.updateForm(store.state);
+                  // Helpers.changeFocus(context, genreFocus, bloodTypeFocus);
+                },
+              ),
+              const SizedBox(height: 15),
+              if (store.isUnderage()) const ResponsableDataFormWidget(),
             ],
           ),
         );

--- a/packages/omni_auth/lib/src/modules/register/stores/register_store.dart
+++ b/packages/omni_auth/lib/src/modules/register/stores/register_store.dart
@@ -5,9 +5,19 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_triple/flutter_triple.dart';
 import 'package:omni_auth/src/modules/register/register_repository.dart';
 import 'package:omni_general/omni_general.dart'
-    show AddressModel, BeneficiaryModel, Formaters, IndividualPersonModel, LecuponRepository, LecuponService, NewBeneficiaryModel, UserModel, ZipCodeStore;
+    show
+        AddressModel,
+        BeneficiaryModel,
+        Formaters,
+        IndividualPersonModel,
+        LecuponRepository,
+        LecuponService,
+        NewBeneficiaryModel,
+        UserModel,
+        ZipCodeStore;
 
-class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel> with Disposable {
+class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
+    with Disposable {
   final RegisterRepository _repository = Modular.get();
   final ZipCodeStore zipCodeStore = ZipCodeStore();
   final LecuponService lecuponService = LecuponService();
@@ -34,7 +44,8 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel> with Di
           ..termsAccepted = state.termsAccepted
           ..programCode = beneficiary.programCode ?? state.programCode
           ..responsible = beneficiary.responsible ?? state.responsible
-          ..individualPerson = beneficiary.individualPerson ?? state.individualPerson,
+          ..individualPerson =
+              beneficiary.individualPerson ?? state.individualPerson,
       );
       setLoading(false);
     }).catchError((onError) {
@@ -91,10 +102,14 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel> with Di
     try {
       switch (page) {
         case 0:
-          final bool isDisable = (state.individualPerson!.birth == null || state.individualPerson!.birth!.isEmpty) ||
-              (state.individualPerson!.cpf == null || state.individualPerson!.cpf!.isEmpty) ||
-              (state.individualPerson!.name == null || state.individualPerson!.name!.isEmpty) ||
-              (state.individualPerson!.phone == null || state.individualPerson!.phone!.isEmpty) ||
+          final bool isDisable = (state.individualPerson!.birth == null ||
+                  state.individualPerson!.birth!.isEmpty) ||
+              (state.individualPerson!.cpf == null ||
+                  state.individualPerson!.cpf!.isEmpty) ||
+              (state.individualPerson!.name == null ||
+                  state.individualPerson!.name!.isEmpty) ||
+              (state.individualPerson!.phone == null ||
+                  state.individualPerson!.phone!.isEmpty) ||
               state.individualPerson!.genre == null;
           return isDisable;
         case 1:
@@ -105,31 +120,45 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel> with Di
             if (state.responsible == null) {
               isUnderageValid = true;
             } else {
-              isUnderageValid = (state.responsible!.name == null || state.responsible!.name!.isEmpty) ||
-                  (state.responsible!.cpf == null || state.responsible!.cpf!.isEmpty) ||
+              isUnderageValid = (state.responsible!.name == null ||
+                      state.responsible!.name!.isEmpty) ||
+                  (state.responsible!.cpf == null ||
+                      state.responsible!.cpf!.isEmpty) ||
                   (state.responsible!.type == null);
             }
           } else {
             isUnderageValid = false;
           }
-          final bool isDisable = (state.individualPerson!.name == null || state.individualPerson!.name!.isEmpty) ||
-              (state.individualPerson!.phone == null || state.individualPerson!.phone!.isEmpty) ||
+          final bool isDisable = (state.individualPerson!.name == null ||
+                  state.individualPerson!.name!.isEmpty) ||
+              (state.individualPerson!.phone == null ||
+                  state.individualPerson!.phone!.isEmpty) ||
               isUnderageValid;
 
           return isDisable;
         case 3:
-          final bool isDisable = (state.individualPerson!.address!.zipCode == null || state.individualPerson!.address!.zipCode!.isEmpty) ||
-              (state.individualPerson!.address!.city == null || state.individualPerson!.address!.city!.isEmpty) ||
-              (state.individualPerson!.address!.state == null || state.individualPerson!.address!.state!.isEmpty) ||
-              (state.individualPerson!.address!.street == null || state.individualPerson!.address!.street!.isEmpty) ||
-              (state.individualPerson!.address!.district == null || state.individualPerson!.address!.district!.isEmpty);
+          final bool isDisable =
+              (state.individualPerson!.address!.zipCode == null ||
+                      state.individualPerson!.address!.zipCode!.isEmpty) ||
+                  (state.individualPerson!.address!.city == null ||
+                      state.individualPerson!.address!.city!.isEmpty) ||
+                  (state.individualPerson!.address!.state == null ||
+                      state.individualPerson!.address!.state!.isEmpty) ||
+                  (state.individualPerson!.address!.street == null ||
+                      state.individualPerson!.address!.street!.isEmpty) ||
+                  (state.individualPerson!.address!.district == null ||
+                      state.individualPerson!.address!.district!.isEmpty);
 
           return isDisable;
         case 4:
-          final bool isDisable = (state.individualPerson!.user!.username == null || state.individualPerson!.user!.username!.isEmpty) ||
-              (state.individualPerson!.user!.email == null || state.individualPerson!.user!.email!.isEmpty) ||
-              (state.individualPerson!.user!.password == null || state.individualPerson!.user!.password!.isEmpty) ||
-              !state.termsAccepted;
+          final bool isDisable =
+              (state.individualPerson!.user!.username == null ||
+                      state.individualPerson!.user!.username!.isEmpty) ||
+                  (state.individualPerson!.user!.email == null ||
+                      state.individualPerson!.user!.email!.isEmpty) ||
+                  (state.individualPerson!.user!.password == null ||
+                      state.individualPerson!.user!.password!.isEmpty) ||
+                  !state.termsAccepted;
           return isDisable;
 
         default:

--- a/packages/omni_auth/lib/src/modules/register/stores/register_store.dart
+++ b/packages/omni_auth/lib/src/modules/register/stores/register_store.dart
@@ -5,19 +5,9 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_triple/flutter_triple.dart';
 import 'package:omni_auth/src/modules/register/register_repository.dart';
 import 'package:omni_general/omni_general.dart'
-    show
-        AddressModel,
-        BeneficiaryModel,
-        Formaters,
-        IndividualPersonModel,
-        LecuponRepository,
-        LecuponService,
-        NewBeneficiaryModel,
-        UserModel,
-        ZipCodeStore;
+    show AddressModel, BeneficiaryModel, Formaters, IndividualPersonModel, LecuponRepository, LecuponService, NewBeneficiaryModel, UserModel, ZipCodeStore;
 
-class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
-    with Disposable {
+class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel> with Disposable {
   final RegisterRepository _repository = Modular.get();
   final ZipCodeStore zipCodeStore = ZipCodeStore();
   final LecuponService lecuponService = LecuponService();
@@ -44,8 +34,7 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
           ..termsAccepted = state.termsAccepted
           ..programCode = beneficiary.programCode ?? state.programCode
           ..responsible = beneficiary.responsible ?? state.responsible
-          ..individualPerson =
-              beneficiary.individualPerson ?? state.individualPerson,
+          ..individualPerson = beneficiary.individualPerson ?? state.individualPerson,
       );
       setLoading(false);
     }).catchError((onError) {
@@ -67,16 +56,20 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
   }
 
   bool isUnderage() {
-    final int ageInDays = DateTime.now()
-        .difference(
-          Formaters.stringToDate(
-            state.individualPerson!.birth!,
-            format: 'dd/MM/yyyy',
-          ),
-        )
-        .inDays;
+    if (state.individualPerson?.birth != null) {
+      final int ageInDays = DateTime.now()
+          .difference(
+            Formaters.stringToDate(
+              state.individualPerson!.birth!,
+              format: 'dd/MM/yyyy',
+            ),
+          )
+          .inDays;
 
-    return (ageInDays / 365.25) < 18;
+      return (ageInDays / 365.25) < 18;
+    } else {
+      return false;
+    }
   }
 
   Future<void> registerBeneficiary(NewBeneficiaryModel data) async {
@@ -98,10 +91,11 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
     try {
       switch (page) {
         case 0:
-          final bool isDisable = (state.individualPerson!.birth == null ||
-                  state.individualPerson!.birth!.isEmpty) ||
-              (state.individualPerson!.cpf == null ||
-                  state.individualPerson!.cpf!.isEmpty);
+          final bool isDisable = (state.individualPerson!.birth == null || state.individualPerson!.birth!.isEmpty) ||
+              (state.individualPerson!.cpf == null || state.individualPerson!.cpf!.isEmpty) ||
+              (state.individualPerson!.name == null || state.individualPerson!.name!.isEmpty) ||
+              (state.individualPerson!.phone == null || state.individualPerson!.phone!.isEmpty) ||
+              state.individualPerson!.genre == null;
           return isDisable;
         case 1:
           return state.programCode == null || state.programCode!.isEmpty;
@@ -111,45 +105,31 @@ class RegisterStore extends NotifierStore<DioError, NewBeneficiaryModel>
             if (state.responsible == null) {
               isUnderageValid = true;
             } else {
-              isUnderageValid = (state.responsible!.name == null ||
-                      state.responsible!.name!.isEmpty) ||
-                  (state.responsible!.cpf == null ||
-                      state.responsible!.cpf!.isEmpty) ||
+              isUnderageValid = (state.responsible!.name == null || state.responsible!.name!.isEmpty) ||
+                  (state.responsible!.cpf == null || state.responsible!.cpf!.isEmpty) ||
                   (state.responsible!.type == null);
             }
           } else {
             isUnderageValid = false;
           }
-          final bool isDisable = (state.individualPerson!.name == null ||
-                  state.individualPerson!.name!.isEmpty) ||
-              (state.individualPerson!.phone == null ||
-                  state.individualPerson!.phone!.isEmpty) ||
+          final bool isDisable = (state.individualPerson!.name == null || state.individualPerson!.name!.isEmpty) ||
+              (state.individualPerson!.phone == null || state.individualPerson!.phone!.isEmpty) ||
               isUnderageValid;
 
           return isDisable;
         case 3:
-          final bool isDisable =
-              (state.individualPerson!.address!.zipCode == null ||
-                      state.individualPerson!.address!.zipCode!.isEmpty) ||
-                  (state.individualPerson!.address!.city == null ||
-                      state.individualPerson!.address!.city!.isEmpty) ||
-                  (state.individualPerson!.address!.state == null ||
-                      state.individualPerson!.address!.state!.isEmpty) ||
-                  (state.individualPerson!.address!.street == null ||
-                      state.individualPerson!.address!.street!.isEmpty) ||
-                  (state.individualPerson!.address!.district == null ||
-                      state.individualPerson!.address!.district!.isEmpty);
+          final bool isDisable = (state.individualPerson!.address!.zipCode == null || state.individualPerson!.address!.zipCode!.isEmpty) ||
+              (state.individualPerson!.address!.city == null || state.individualPerson!.address!.city!.isEmpty) ||
+              (state.individualPerson!.address!.state == null || state.individualPerson!.address!.state!.isEmpty) ||
+              (state.individualPerson!.address!.street == null || state.individualPerson!.address!.street!.isEmpty) ||
+              (state.individualPerson!.address!.district == null || state.individualPerson!.address!.district!.isEmpty);
 
           return isDisable;
         case 4:
-          final bool isDisable =
-              (state.individualPerson!.user!.username == null ||
-                      state.individualPerson!.user!.username!.isEmpty) ||
-                  (state.individualPerson!.user!.email == null ||
-                      state.individualPerson!.user!.email!.isEmpty) ||
-                  (state.individualPerson!.user!.password == null ||
-                      state.individualPerson!.user!.password!.isEmpty) ||
-                  !state.termsAccepted;
+          final bool isDisable = (state.individualPerson!.user!.username == null || state.individualPerson!.user!.username!.isEmpty) ||
+              (state.individualPerson!.user!.email == null || state.individualPerson!.user!.email!.isEmpty) ||
+              (state.individualPerson!.user!.password == null || state.individualPerson!.user!.password!.isEmpty) ||
+              !state.termsAccepted;
           return isDisable;
 
         default:

--- a/packages/omni_general/lib/src/core/models/lecupom_models/activate_user_model.dart
+++ b/packages/omni_general/lib/src/core/models/lecupom_models/activate_user_model.dart
@@ -3,7 +3,7 @@ class ActivateUserModel {
   String? name;
   String? email;
   String? cpf;
-  String? phone;
+  String? cellphone;
   bool? active;
   String? createdAt;
   String? updatedAt;
@@ -16,7 +16,7 @@ class ActivateUserModel {
     this.cpf,
     this.email,
     this.name,
-    this.phone,
+    this.cellphone,
     this.createdAt,
     this.updatedAt,
     this.userTags,
@@ -28,12 +28,12 @@ class ActivateUserModel {
     name = json['name'];
     email = json['email'];
     cpf = json['cpf'];
-    phone = json['phone'];
+    cellphone = json['cellphone'];
     active = json['active'];
     if (json['user_tags'] != null) {
       userTags = List.empty(growable: true);
       json['user_tags'].forEach((element) {
-        userTags?.add(element);
+        userTags?.add(element['name']);
       });
     }
     password = json['password'];
@@ -48,7 +48,7 @@ class ActivateUserModel {
     data['name'] = name;
     data['email'] = email;
     data['cpf'] = cpf;
-    data['phone'] = phone;
+    data['cellphone'] = cellphone;
     data['activated_at'] = active;
     data['created_at'] = createdAt;
     data['updated_at'] = updatedAt;

--- a/packages/omni_general/lib/src/core/repositories/lecupon_repository.dart
+++ b/packages/omni_general/lib/src/core/repositories/lecupon_repository.dart
@@ -133,7 +133,7 @@ class LecuponRepository extends Disposable {
   }) async {
     try {
       final Response response = await _httpClientImpl.post(
-        path: '/api/v1/public_integration/users',
+        path: '/client/v2/businesses/$cnpj/users',
         data: activateUser.toJson(),
       );
 

--- a/packages/omni_general/lib/src/core/services/lecupon_service.dart
+++ b/packages/omni_general/lib/src/core/services/lecupon_service.dart
@@ -12,21 +12,18 @@ class LecuponService {
   }) async {
     await _lecuponRepository.getAdmminToken();
     await _lecuponRepository
-        .createAuthorizedUser(
-          activeUser: ActivateUserModel(
+        .registerUser(
+          activateUser: ActivateUserModel(
             name: beneficiary.individualPerson?.name,
             cpf: beneficiary.individualPerson?.cpf,
             email: beneficiary.individualPerson?.user?.email,
-            phone: beneficiary.individualPerson?.phone,
+            cellphone: beneficiary.individualPerson?.phone,
+            password: beneficiary.individualPerson?.user?.password,
+            userTags: [beneficiary.programCode!],
             active: true,
           ),
         )
-        .then((value) => activateUser = value);
-    await _lecuponRepository
-        .registerUser(activateUser: activateUser)
         .then((value) => lecuponUser = value);
-
-    activateUser.cpf = beneficiary.individualPerson?.cpf;
 
     return lecuponUser;
   }


### PR DESCRIPTION
Mudanças no layout de cadastro:
- adicionado campos na primeira tela do cadastro para agilizar o cadastro
- removida uma tela do cadastro por não ter necessidade daqueles campos
- API da Lecupom foi modificada o campo "phone" para "cellphone", por conta disso foi alterado o model, sem esta alteração a LEcupom não setava o telefone do usuário na plataforma deles
- Foi modificado a URL de chamada da Lecupom, dado que não há mais necessidade de chamar um dos endpoint previamente exigidos.